### PR TITLE
Allow Unicode characters including emojis in nicknames

### DIFF
--- a/bitchat.py
+++ b/bitchat.py
@@ -1541,9 +1541,9 @@ class BitchatClient:
             elif len(new_name) > 20:
                 print("\033[93m⚠ Nickname too long\033[0m")
                 print("\033[90mMaximum 20 characters allowed.\033[0m")
-            elif not all(c.isalnum() or c in '-_' for c in new_name):
+            elif any(c in '\n\r\t\0' for c in new_name):
                 print("\033[93m⚠ Invalid nickname\033[0m")
-                print("\033[90mNicknames can only contain letters, numbers, hyphens and underscores.\033[0m")
+                print("\033[90mNicknames cannot contain control characters.\033[0m")
             elif new_name in ["system", "all"]:
                 print("\033[93m⚠ Reserved nickname\033[0m")
                 print("\033[90mThis nickname is reserved and cannot be used.\033[0m")


### PR DESCRIPTION
🌍 Allow Unicode characters including emojis in nicknames
This update removes the restrictive alphanumeric-only validation for nicknames and replaces it with Unicode-friendly validation that allows emojis and international characters while still preventing potentially harmful control characters.

Changes:

Replaced [isalnum()](vscode-file://vscode-app/c:/Users/jtset/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) check with control character filtering
Users can now use emojis like 🟧Python, 🚀Alice, or international names like José, محمد
Still blocks control characters (\n, \r, \t, \0) for security
Maintains existing length limits and reserved name restrictions

Example usage:
```
> /name 🟧Python
» Nickname changed to: 🟧Python
```
This makes BitChat more inclusive and expressive while maintaining security standards! 🎉